### PR TITLE
Add an entrypoint for easy use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,5 @@ RUN apk add --no-cache --virtual=build-dependencies wget ca-certificates build-b
     wget "https://bootstrap.pypa.io/get-pip.py" -O /dev/stdout | python3 && \
     pip3 install attic && \
     apk del build-dependencies
+
+ENTRYPOINT ["attic"]


### PR DESCRIPTION
Removes the double attic, and now this works

```
$ docker run bwaldher/attic
usage: attic [-h]
             {serve,init,check,change-passphrase,create,extract,delete,list,mount,info,prune,help}
             ...

Attic 0.16 - Deduplicated Backups

optional arguments:
  -h, --help            show this help message and exit

Available commands:
  {serve,init,check,change-passphrase,create,extract,delete,list,mount,info,prune,help}
```

normal usage

```
docker run -v /:/os bwaldher/attic init /os/var/repo
docker run -v /:/os bwaldher/attic create /os/var/repo::backup /os/my/files
```
